### PR TITLE
[replace] window.open to window.location.assign

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,7 +13,7 @@ import { useGoogleLogin } from '~/core/03-composables/useGoogleLogin'
 export default defineComponent({
   setup() {
     const onLoginButtonClick = () => {
-      useGoogleLogin().then((res) => window.open(res.redirectUrl))
+      useGoogleLogin().then((res) => window.location.assign(res.redirectUrl))
     }
     return { onLoginButtonClick }
   },

--- a/pages/mc/login.vue
+++ b/pages/mc/login.vue
@@ -32,7 +32,7 @@ export default defineComponent({
   setup() {
     const { headerText, loginButton } = useComponentComposables()
     const onLoginButtonClick = () => {
-      useGoogleLogin().then((res) => window.open(res.redirectUrl))
+      useGoogleLogin().then((res) => window.location.assign(res.redirectUrl))
     }
     return { headerText, loginButton, onLoginButtonClick }
   },


### PR DESCRIPTION
googleログインリンクの遷移方法を`window.open`から`window.location.assign`にしました。(よくあるサービスっぽくなりました)